### PR TITLE
Add minimum for an invoice form

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "@chakra-ui/react": "^1.2.1",
     "@emotion/react": "^11.1.4",
     "@emotion/styled": "^11.0.0",
+    "formik": "^2.2.6",
     "framer-motion": "^3.2.2-rc.1",
     "next": "^10.0.6",
     "react": "^17.0.1",
-    "react-dom": "^17.0.1"
+    "react-dom": "^17.0.1",
+    "yup": "^0.32.8"
   },
   "devDependencies": {
     "@types/node": "^14.14.27",

--- a/src/components/formik/CheckboxField.tsx
+++ b/src/components/formik/CheckboxField.tsx
@@ -1,0 +1,22 @@
+import { FormControl, FormLabel, Checkbox } from '@chakra-ui/react';
+import { FastField, FieldProps } from 'formik';
+import React from 'react';
+import { fieldProps } from './InputField';
+
+export const CheckboxField: React.FC<fieldProps> = ({ name, label }) => {
+  return (
+    <FastField name={name}>
+      {({ meta, field }: FieldProps) => {
+        const isInvalid = !!meta.error && meta.touched;
+        return (
+          <>
+            <FormControl name={name} isInvalid={isInvalid}>
+              {label ? <FormLabel htmlFor={name}>{label}</FormLabel> : null}
+              <Checkbox isInvalid={isInvalid} id={name} {...field} />
+            </FormControl>
+          </>
+        );
+      }}
+    </FastField>
+  );
+};

--- a/src/components/formik/CheckboxField.tsx
+++ b/src/components/formik/CheckboxField.tsx
@@ -3,6 +3,10 @@ import { FastField, FieldProps } from 'formik';
 import React from 'react';
 import { fieldProps } from './formikFieldTypes';
 
+/**
+ * Custom Formik Field that returns JSX of a Chakra-ui Checkbox w/ predefined styling
+ */
+
 export const CheckboxField: React.FC<fieldProps> = ({ name, label }) => {
   return (
     <FastField name={name}>

--- a/src/components/formik/CheckboxField.tsx
+++ b/src/components/formik/CheckboxField.tsx
@@ -1,7 +1,7 @@
 import { FormControl, FormLabel, Checkbox } from '@chakra-ui/react';
 import { FastField, FieldProps } from 'formik';
 import React from 'react';
-import { fieldProps } from './InputField';
+import { fieldProps } from './formikFieldTypes';
 
 export const CheckboxField: React.FC<fieldProps> = ({ name, label }) => {
   return (

--- a/src/components/formik/InputField.tsx
+++ b/src/components/formik/InputField.tsx
@@ -1,22 +1,18 @@
 import {
+  Flex,
   FormControl,
   FormErrorMessage,
   FormLabel,
   Input,
 } from '@chakra-ui/react';
 import { FastField, FieldProps } from 'formik';
-import { InputHTMLAttributes } from 'react';
-
-export type fieldProps = InputHTMLAttributes<HTMLInputElement> & {
-  name: string;
-  label?: string;
-  placeholder?: string;
-};
+import { fieldProps } from './formikFieldTypes';
 
 export const InputField: React.FC<fieldProps> = ({
   name,
   label,
   placeholder,
+  labelDir,
 }) => {
   return (
     <>
@@ -25,15 +21,17 @@ export const InputField: React.FC<fieldProps> = ({
           const isInvalid = !!meta.error && meta.touched;
           return (
             <FormControl name={name} isInvalid={isInvalid}>
-              {label ? <FormLabel htmlFor={name}>{label}</FormLabel> : null}
-              <Input
-                {...field}
-                id={name}
-                isInvalid={isInvalid}
-                name={name}
-                placeholder={placeholder}
-                errortext={meta.error}
-              ></Input>
+              <Flex flexDir={labelDir || 'column'} p={1}>
+                {label ? <FormLabel htmlFor={name}>{label}</FormLabel> : null}
+                <Input
+                  {...field}
+                  id={name}
+                  isInvalid={isInvalid}
+                  name={name}
+                  placeholder={placeholder}
+                  errortext={meta.error}
+                ></Input>
+              </Flex>
               <FormErrorMessage>{meta.error}</FormErrorMessage>
             </FormControl>
           );

--- a/src/components/formik/InputField.tsx
+++ b/src/components/formik/InputField.tsx
@@ -1,0 +1,44 @@
+import {
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+} from '@chakra-ui/react';
+import { FastField, FieldProps } from 'formik';
+import { InputHTMLAttributes } from 'react';
+
+export type fieldProps = InputHTMLAttributes<HTMLInputElement> & {
+  name: string;
+  label?: string;
+  placeholder?: string;
+};
+
+export const InputField: React.FC<fieldProps> = ({
+  name,
+  label,
+  placeholder,
+}) => {
+  return (
+    <>
+      <FastField name={name}>
+        {({ field, meta }: FieldProps) => {
+          const isInvalid = !!meta.error && meta.touched;
+          return (
+            <FormControl name={name} isInvalid={isInvalid}>
+              {label ? <FormLabel htmlFor={name}>{label}</FormLabel> : null}
+              <Input
+                {...field}
+                id={name}
+                isInvalid={isInvalid}
+                name={name}
+                placeholder={placeholder}
+                errortext={meta.error}
+              ></Input>
+              <FormErrorMessage>{meta.error}</FormErrorMessage>
+            </FormControl>
+          );
+        }}
+      </FastField>
+    </>
+  );
+};

--- a/src/components/formik/InputField.tsx
+++ b/src/components/formik/InputField.tsx
@@ -8,11 +8,16 @@ import {
 import { FastField, FieldProps } from 'formik';
 import { fieldProps } from './formikFieldTypes';
 
+/**
+ * Custom Formik Field that returns JSX of a Chakra-ui Input w/ predefined styling
+ */
+
 export const InputField: React.FC<fieldProps> = ({
   name,
   label,
   placeholder,
-  labelDir,
+  labelDir = 'column',
+  autoComplete = 'off',
 }) => {
   return (
     <>
@@ -21,9 +26,10 @@ export const InputField: React.FC<fieldProps> = ({
           const isInvalid = !!meta.error && meta.touched;
           return (
             <FormControl name={name} isInvalid={isInvalid}>
-              <Flex flexDir={labelDir || 'column'} p={1}>
+              <Flex flexDir={labelDir} p={1}>
                 {label ? <FormLabel htmlFor={name}>{label}</FormLabel> : null}
                 <Input
+                  autoComplete={autoComplete}
                   {...field}
                   id={name}
                   isInvalid={isInvalid}

--- a/src/components/formik/formikFieldTypes.ts
+++ b/src/components/formik/formikFieldTypes.ts
@@ -1,8 +1,17 @@
 import { InputHTMLAttributes } from 'react';
 
+/**
+ * @property {string} `name` - of component/item in form to allow formik to handle props for inputs
+ * @property {string || undefined} `label` - that is used in FormLabel from Chakra-ui
+ * @property {string || undefined} `placeholder` - passed into inputs
+ * @property {string || undefined} `labelDir` - flex attribute which changes positioning for form label that defaults to column
+ * @property {string || undefined} `autoComplete` - attribute that enables browser autocompletion; defaults to off
+ */
+
 export type fieldProps = InputHTMLAttributes<HTMLInputElement> & {
   name: string;
   label?: string;
   placeholder?: string;
   labelDir?: 'column' | 'row';
+  autoComplete?: 'on' | 'off';
 };

--- a/src/components/formik/formikFieldTypes.ts
+++ b/src/components/formik/formikFieldTypes.ts
@@ -1,0 +1,8 @@
+import { InputHTMLAttributes } from 'react';
+
+export type fieldProps = InputHTMLAttributes<HTMLInputElement> & {
+  name: string;
+  label?: string;
+  placeholder?: string;
+  labelDir?: 'column' | 'row';
+};

--- a/src/components/invoice/invoiceCustomerAndVehicleForm.tsx
+++ b/src/components/invoice/invoiceCustomerAndVehicleForm.tsx
@@ -1,0 +1,42 @@
+import { Flex } from '@chakra-ui/react';
+import React from 'react';
+import { InputField } from '../formik/InputField';
+
+export const CustomerAndVehicleForm = () => (
+  <>
+    <Flex>
+      <InputField
+        label="First Name"
+        placeholder="John"
+        name="customer.first_name"
+      />
+      <InputField
+        label="Last Name"
+        placeholder="Smith"
+        type="name"
+        name="customer.last_name"
+      />
+      <InputField
+        label="Phone Number"
+        placeholder="000-000-0000"
+        name="customer.number"
+      />
+      <InputField
+        label="Optional Number"
+        placeholder="000-000-0000"
+        type=""
+        name="customer.number_2"
+      />
+    </Flex>
+
+    <Flex>
+      <InputField label="Year" placeholder="2000" name="car.year" />
+      <InputField label="Color" placeholder="Black" name="car.color" />
+      <InputField label="Type" placeholder="Honda" name="car.type" />
+      <InputField label="Make" placeholder="Accord" name="car.make" />
+      <InputField label="License" placeholder="1A2B3C4" name="car.license" />
+      <InputField label="Vin" placeholder="123ABC" name="car.vin" />
+      <InputField label="milage" placeholder="000,000" name="car.milage" />
+    </Flex>
+  </>
+);

--- a/src/components/invoice/invoiceForm.tsx
+++ b/src/components/invoice/invoiceForm.tsx
@@ -1,0 +1,58 @@
+import {
+  Box,
+  Heading,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+} from '@chakra-ui/react';
+import { Form, Formik } from 'formik';
+import React from 'react';
+import { CustomerAndVehicleForm } from './invoiceCustomerAndVehicleForm';
+import { initialValues } from './invoiceInitialValues';
+import { TicketForm } from './invoiceTicketForm';
+
+/**
+ * Form of an invoice utilizing `Formik for form management and `Yup` for validation w/ predefined styling
+ */
+const InvoiceForm = () => {
+  return (
+    <Box pt={8} pb={30} mx="auto" height="90vh" maxW="900px">
+      <Heading>Invoice</Heading>
+      <Formik initialValues={initialValues} onSubmit={async () => {}}>
+        {({ values }) => (
+          <>
+            <Form>
+              <Tabs
+                isFitted
+                isManual
+                variant="solid-rounded"
+                colorScheme="gray"
+              >
+                <TabList mb="1em">
+                  <Tab>Customer</Tab>
+                  <Tab>Invoice</Tab>
+                </TabList>
+
+                <TabPanels>
+                  <TabPanel>
+                    <CustomerAndVehicleForm />
+                  </TabPanel>
+
+                  <TabPanel>
+                    <TicketForm />
+                  </TabPanel>
+                </TabPanels>
+              </Tabs>
+            </Form>
+
+            <pre>{JSON.stringify(values, null, 2)}</pre>
+          </>
+        )}
+      </Formik>
+    </Box>
+  );
+};
+
+export default InvoiceForm;

--- a/src/components/invoice/invoiceForm.tsx
+++ b/src/components/invoice/invoiceForm.tsx
@@ -41,13 +41,11 @@ const InvoiceForm = () => {
                   </TabPanel>
 
                   <TabPanel>
-                    <TicketForm />
+                    <TicketForm ticket={values.ticket} />
                   </TabPanel>
                 </TabPanels>
               </Tabs>
             </Form>
-
-            <pre>{JSON.stringify(values, null, 2)}</pre>
           </>
         )}
       </Formik>
@@ -55,4 +53,5 @@ const InvoiceForm = () => {
   );
 };
 
+// <pre>{JSON.stringify(values, null, 2)}</pre>
 export default InvoiceForm;

--- a/src/components/invoice/invoiceInitialValues.ts
+++ b/src/components/invoice/invoiceInitialValues.ts
@@ -1,4 +1,4 @@
-import { invoice } from '../../types';
+import { invoice, inv_labor, inv_part } from '../../types';
 
 /**
  * Initial values for an invoice used/passed into `Formik`
@@ -26,4 +26,18 @@ export const initialValues: invoice = {
     save_for_package_job: false,
     tax_exempt: false,
   },
+};
+
+export const initialInvoicePart: inv_part = {
+  quantity_used: 0,
+  total: '',
+  price: '',
+  description: '',
+};
+
+export const initialInvoiceLabor: inv_labor = {
+  hours_worked: 0,
+  total: '',
+  price: '',
+  description: '',
 };

--- a/src/components/invoice/invoiceInitialValues.ts
+++ b/src/components/invoice/invoiceInitialValues.ts
@@ -1,0 +1,29 @@
+import { invoice } from '../../types';
+
+/**
+ * Initial values for an invoice used/passed into `Formik`
+ */
+export const initialValues: invoice = {
+  customer: {
+    first_name: '',
+    last_name: '',
+    number: '',
+  },
+  car: {
+    year: '',
+    color: '',
+    type: '',
+    make: '',
+    license: '',
+    vin: '',
+    milage: '',
+  },
+  ticket: {
+    total: '',
+    sub_total: '',
+    service: [],
+    misc_charges: '',
+    save_for_package_job: false,
+    tax_exempt: false,
+  },
+};

--- a/src/components/invoice/invoiceTicketForm.tsx
+++ b/src/components/invoice/invoiceTicketForm.tsx
@@ -1,9 +1,8 @@
 import { Flex } from '@chakra-ui/react';
 import React from 'react';
 import { CheckboxField } from '../formik/CheckboxField';
-import { fieldProps } from '../formik/InputField';
 
-export const TicketForm: React.FC<fieldProps> = () => {
+export const TicketForm: React.FC = () => {
   return (
     <>
       <Flex>

--- a/src/components/invoice/invoiceTicketForm.tsx
+++ b/src/components/invoice/invoiceTicketForm.tsx
@@ -1,16 +1,88 @@
-import { Flex } from '@chakra-ui/react';
+import { Button, Flex, FormLabel } from '@chakra-ui/react';
+import { ArrayHelpers, FieldArray } from 'formik';
 import React from 'react';
+import { invoice, inv_ticket } from '../../types';
 import { CheckboxField } from '../formik/CheckboxField';
+import { InputField } from '../formik/InputField';
+import {
+  initialInvoiceLabor,
+  initialInvoicePart,
+} from './invoiceInitialValues';
 
-export const TicketForm: React.FC = () => {
+export const TicketForm: React.FC<{ ticket: inv_ticket }> = ({ ticket }) => {
   return (
     <>
-      <Flex>
-        <CheckboxField name="ticket.tax_exempt" label="Tax Exempt" />
-        <CheckboxField
-          name="ticket.save_for_package_job"
-          label="Save For Package"
-        />
+      <Flex flexDir="column">
+        <FieldArray name="ticket.service">
+          {({ remove, push }: ArrayHelpers) => {
+            return (
+              <Flex flexDir="column">
+                <Flex>
+                  <Button
+                    m={2}
+                    type="button"
+                    onClick={() => push(initialInvoicePart)}
+                  >
+                    Add Part
+                  </Button>
+                  <Button
+                    m={2}
+                    type="button"
+                    onClick={() => push(initialInvoiceLabor)}
+                  >
+                    Add Labor
+                  </Button>
+                </Flex>
+
+                {ticket.service.length > 0 &&
+                  ticket.service.map((item, index) => {
+                    const {
+                      itemName,
+                      label,
+                      amountLabel,
+                    } = item?.hasOwnProperty('hours_worked')
+                      ? {
+                          itemName: 'hours_worked',
+                          amountLabel: 'Hrs.',
+                          label: 'Labor',
+                        }
+                      : item?.hasOwnProperty('quantity_used')
+                      ? {
+                          itemName: 'quantity_used',
+                          amountLabel: 'Qty.',
+                          label: 'Parts',
+                        }
+                      : { itemName: '', amountLabel: '', label: '' };
+
+                    return (
+                      <Flex>
+                        <FormLabel>{label}</FormLabel>
+                        <InputField
+                          labelDir="row"
+                          placeholder="Desc...."
+                          name={`ticket.service.${index}.description`}
+                        />
+                        <InputField
+                          labelDir="row"
+                          name={`ticket.service.${index}.${itemName}`}
+                          label={amountLabel}
+                        />
+                        <Button onClick={() => remove(index)}>x</Button>
+                      </Flex>
+                    );
+                  })}
+              </Flex>
+            );
+          }}
+        </FieldArray>
+
+        <Flex>
+          <CheckboxField name="ticket.tax_exempt" label="Tax Exempt" />
+          <CheckboxField
+            name="ticket.save_for_package_job"
+            label="Save For Package"
+          />
+        </Flex>
       </Flex>
     </>
   );

--- a/src/components/invoice/invoiceTicketForm.tsx
+++ b/src/components/invoice/invoiceTicketForm.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, FormLabel } from '@chakra-ui/react';
 import { ArrayHelpers, FieldArray } from 'formik';
 import React from 'react';
-import { invoice, inv_ticket } from '../../types';
+import { inv_ticket } from '../../types';
 import { CheckboxField } from '../formik/CheckboxField';
 import { InputField } from '../formik/InputField';
 import {

--- a/src/components/invoice/invoiceTicketForm.tsx
+++ b/src/components/invoice/invoiceTicketForm.tsx
@@ -1,0 +1,18 @@
+import { Flex } from '@chakra-ui/react';
+import React from 'react';
+import { CheckboxField } from '../formik/CheckboxField';
+import { fieldProps } from '../formik/InputField';
+
+export const TicketForm: React.FC<fieldProps> = () => {
+  return (
+    <>
+      <Flex>
+        <CheckboxField name="ticket.tax_exempt" label="Tax Exempt" />
+        <CheckboxField
+          name="ticket.save_for_package_job"
+          label="Save For Package"
+        />
+      </Flex>
+    </>
+  );
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,12 @@
 import { ColorModeSwitch } from '../components/ColorModeSwitch';
 import { Container } from '../components/Container';
+import InvoiceForm from '../components/invoice/invoiceForm';
 
 const Index = () => {
   return (
     <Container>
       <ColorModeSwitch />
+      <InvoiceForm />
     </Container>
   );
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,16 +37,18 @@ export type inv_ticket = {
   tax_exempt: boolean;
 };
 
-type inv_part = {
+export type inv_part = {
   quantity_used: number;
   total: string;
   price: string;
+  description: string;
 };
 
-type inv_labor = {
+export type inv_labor = {
   hours_worked: number;
   total: string;
   price: string;
+  description: string;
 };
 
 export type client = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,12 @@
 export type invoice = {
-  id: string;
+  // id: string;
   car: inv_car;
   customer: inv_customer;
   ticket: inv_ticket;
 };
 
 export type inv_car = {
-  id: string;
+  id?: string;
   year: string;
   color: string;
   type: string;
@@ -14,24 +14,24 @@ export type inv_car = {
   license: string;
   vin: string;
   milage: string;
-  engine_size: string;
-  tags: string;
+  engine_size?: string;
+  tags?: string;
 };
 
 export type inv_customer = {
-  id: string;
+  id?: string;
   first_name: string;
   last_name: string;
   number: string;
-  number_2: string;
-  address: string;
-  email: string;
+  number_2?: string;
+  address?: string;
+  email?: string;
 };
 
 export type inv_ticket = {
   total: string;
   sub_total: string;
-  service: (inv_part | inv_labor)[];
+  service: (inv_part | inv_labor | undefined)[];
   misc_charges: string;
   save_for_package_job: boolean;
   tax_exempt: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -100,6 +100,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.10.5":
+  version "7.12.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.13.tgz#0a21452352b02542db0ffb928ac2d3ca7cb6d66d"
+  integrity sha512-8+3UMPBrjFa/6TtKi/7sehPKqfAm4g6K+YQjyyFOLUTxzOngcRZTlAVY8sc2CORJYqdHQY8gRPHmn+qo15rCBw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/types@7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.3.tgz#5a383dffa5416db1b73dedffd311ffd0788fb31c"
@@ -836,7 +843,7 @@
   dependencies:
     "@types/lodash" "*"
 
-"@types/lodash@*":
+"@types/lodash@*", "@types/lodash@^4.14.165":
   version "4.14.168"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
   integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
@@ -1485,6 +1492,11 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
@@ -1711,6 +1723,19 @@ focus-lock@^0.7.0:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.7.0.tgz#b2bfb0ca7beacc8710a1ff74275fe0dc60a1d88a"
   integrity sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==
 
+formik@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.6.tgz#378a4bafe4b95caf6acf6db01f81f3fe5147559d"
+  integrity sha512-Kxk2zQRafy56zhLmrzcbryUpMBvT0tal5IvcifK5+4YNGelKsnrODFJ0sZQRMQboblWNym4lAW3bt+tf2vApSA==
+  dependencies:
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.14"
+    lodash-es "^4.17.14"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^1.10.0"
+
 framer-motion@^3.2.2-rc.1:
   version "3.2.2-rc.1"
   resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-3.2.2-rc.1.tgz#8fb334484505f01b6b9fc2ce6a770bd71507e53d"
@@ -1843,7 +1868,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -2050,6 +2075,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.17.11, lodash-es@^4.17.14:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.20.tgz#29f6332eefc60e849f869c264bc71126ad61e8f7"
+  integrity sha512-JD1COMZsq8maT6mnuz1UMV0jvYD0E0aUsSOdrr1/nAG3dhqQXwRRgeW0cSqH1U43INKcqxaiVIQNOUDld7gRDA==
+
 lodash.mergewith@4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
@@ -2060,7 +2090,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.13, lodash@^4.17.19:
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -2142,6 +2172,11 @@ ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+nanoclone@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
+  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanoid@^3.1.16:
   version "3.1.20"
@@ -2514,6 +2549,11 @@ prop-types@15.7.2, prop-types@^15.6.2, prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+property-expr@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.4.tgz#37b925478e58965031bb612ec5b3260f8241e910"
+  integrity sha512-sFPkHQjVKheDNnPvotjQmm3KD3uk1fWKUN7CrpdbwmUx3CrG3QiM8QpTSimvig5vTXmTvjz7+TDvXOI9+4rkcg==
+
 public-encrypt@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.3.tgz#4fcc9d77a07e48ba7527e7cbe0de33d0701331e0"
@@ -2614,6 +2654,11 @@ react-fast-compare@3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
+react-fast-compare@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
 react-focus-lock@2.4.1:
   version "2.4.1"
@@ -3078,6 +3123,11 @@ tiny-invariant@^1.0.6:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
 
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tinycolor2@1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
@@ -3109,6 +3159,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
 
 tr46@^1.0.1:
   version "1.0.1"
@@ -3276,3 +3331,16 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^0.32.8:
+  version "0.32.8"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.8.tgz#16e4a949a86a69505abf99fd0941305ac9adfc39"
+  integrity sha512-SZulv5FIZ9d5H99EN5tRCRPXL0eyoYxWIP1AacCrjC9d4DfP13J1dROdKGfpfRHT3eQB6/ikBl5jG21smAfCkA==
+  dependencies:
+    "@babel/runtime" "^7.10.5"
+    "@types/lodash" "^4.14.165"
+    lodash "^4.17.20"
+    lodash-es "^4.17.11"
+    nanoclone "^0.2.1"
+    property-expr "^2.0.4"
+    toposort "^2.0.2"


### PR DESCRIPTION
**Added:**
- Form to gather customer/client information (name, numbers, ...)
- Form to gather vehicle information (model, make, year, ...)
- Form to gather ticket information (tax exempt, labor, parts)
- Form/Component to gather information on description and qty of labor and one for parts
- Basic CSS (Layout) settings
- Generic custom components w/ Formik fields and chakra components
- Tabs to toggle between pages of customer/vehicle information and ticket "jobs"

**Commits:**
- make fields optional - faca141
- add formik and yup for form validation; and include react-dom dependency - 271c3a4
- updated yarn.lock w/ new dependencies - cb92744
- add invoice form to first page - 71cfe51
- add component that contains all logic for the ticket form - 1ae9874
- abstract logic for initial values - 93ef865
- add tabs to bare invoice; set up basic formik; temporary pre tag to preview formchanges - 0d643d8
- add component that contains all logic for the customer and vehicle information form - d047b34
- add generic formik component w/ chakra input - 61ade5c
- add generic custom component that uses formik w/ chakra checkbox - 0a40d3e
- export and add property of item description - 97a3de8
- abstract the types found in `InputField` out to the formik folder - 3573cbe
- abstract props type; allow for css change of label direction - 5ab1a83
- adjust prop types import - 51fcfe1
- completely handle adding labor and parts; removing individual parts/labor; checkboxes for optional ticket toggles; and very basic styling/layout - 2e802a3
- adjust props passed to `TicketForm` - a10c966
- add initial values to part and labor - 6a4e39c
- adjusted imports - 5c69f4a
- add comments that explain the use of the props - 3eea27b
- add jsdoc - 010f8ff
- add jsdoc and add additional props to handle css and browser autocomplete - e6545d1